### PR TITLE
Modified Wolter-Schwarzschild surface functions. If the ray encounter…

### DIFF
--- a/examples/wolterSchwarzschildTest.py
+++ b/examples/wolterSchwarzschildTest.py
@@ -1,0 +1,90 @@
+#This module will test the behavior of the Wolter Schwarzschild surface
+#tracing. Rays are launched at a variety of radii and incidence angles to
+#determine under what conditions the rays are actually traced to the mirror.
+
+import numpy as np
+import matplotlib.pyplot as plt
+import PyXFocus.surfaces as surf
+import PyXFocus.sources as sources
+import PyXFocus.transformations as tran
+import PyXFocus.analyses as anal
+
+def testNormalPrimary(r0,z0,zeta=1.,offx=0.,dz=0.):
+    """
+    Launch a slit of rays toward the mirror from infinity.
+    Return the 
+    """
+    #Set up source
+    rays = sources.circularbeam(r0*2,1e4)
+    tran.transform(rays,0,0,-z0+dz,0,0,0)
+
+    #Apply offaxis angle
+    rays[4] = rays[4] + offx
+    rays[6] = -np.sqrt(1-rays[4]**2)
+
+    #Trace to primary
+    xi = np.copy(rays[1])
+    yi = np.copy(rays[2])
+    surf.wsPrimary(rays,r0,z0,zeta)
+
+    return rays,xi,yi
+
+def testTransversePrimary(r0,z0,zeta=1.,offz=0.,dx=0.):
+    """
+    Launch rays perpendicular to optical axis toward mirror.
+    """
+    #Set up source
+    rays = sources.rectbeam(z0,r0,1e4)
+    tran.transform(rays,0,0,0,0,np.pi/2,0)
+    tran.transform(rays,-r0+dx,0,-z0,0,0,0)
+
+    #Apply offaxis angle
+    rays[6] = rays[6] + offz
+    rays[4] = -np.sqrt(1-rays[6]**2)
+
+    #Trace to primary
+    zi = np.copy(rays[3])
+    yi = np.copy(rays[2])
+    surf.wsPrimary(rays,r0,z0,zeta)
+
+    return rays,yi,zi
+
+def testNormalSecondary(r0,z0,zeta=1.,offx=0.,dz=0.):
+    """
+    Launch a slit of rays toward the mirror from infinity.
+    Return the 
+    """
+    #Set up source
+    rays = sources.circularbeam(r0*2,1e4)
+    tran.transform(rays,0,0,-z0+dz,0,0,0)
+
+    #Apply offaxis angle
+    rays[4] = rays[4] + offx
+    rays[6] = -np.sqrt(1-rays[4]**2)
+
+    #Trace to primary
+    xi = np.copy(rays[1])
+    yi = np.copy(rays[2])
+    surf.wsSecondary(rays,r0,z0,zeta)
+
+    return rays,xi,yi
+
+def testTransverseSecondary(r0,z0,zeta=1.,offz=0.,dx=0.):
+    """
+    Launch rays perpendicular to optical axis toward mirror.
+    """
+    #Set up source
+    rays = sources.rectbeam(z0,r0,1e4)
+    tran.transform(rays,0,0,0,0,np.pi/2,0)
+    tran.transform(rays,-r0+dx,0,-z0,0,0,0)
+
+    #Apply offaxis angle
+    rays[6] = rays[6] + offz
+    rays[4] = -np.sqrt(1-rays[6]**2)
+
+    #Trace to primary
+    zi = np.copy(rays[3])
+    yi = np.copy(rays[2])
+    surf.wsSecondary(rays,r0,z0,zeta)
+
+    return rays,yi,zi

--- a/woltsurf.f95
+++ b/woltsurf.f95
@@ -391,7 +391,7 @@ subroutine wsprimary(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi)
   real*8 , intent(inout) :: x(num),y(num),z(num),l(num),m(num),n(num),ux(num),uy(num),uz(num)
   real*8, intent(in) :: alpha,z0,psi
   real*8 :: k,kterm,dbdx,dbdy,beta,betas,ff,g,r
-  real*8 :: F,Fx,Fy,Fz,Fp,delt,dum,Fb
+  real*8 :: F,Fx,Fy,Fz,Fp,delt,dum,Fb,xi,yi,zi
   integer :: i, flag, c
 
   !Compute Chase parameters
@@ -401,10 +401,14 @@ subroutine wsprimary(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi)
   k = tan(betas/2)**2
 
   !Loop through rays and trace to mirror
-  !$omp parallel do private(i,delt,F,Fx,Fy,Fz,Fp,Fb,kterm,beta,dbdx,dbdy,flag,r)
+  !$omp parallel do private(i,delt,F,Fx,Fy,Fz,Fp,Fb,kterm,beta,dbdx,dbdy,flag,r,xi,yi,zi)
   do i=1,num
     delt = 100.
     c = 0
+    !Initial ray position
+    xi = x(i)
+    yi = y(i)
+    zi = z(i)
     do while(abs(delt)>1.e-8)
       beta = asin(sqrt(x(i)**2 + y(i)**2)/ff)
       flag = 0
@@ -437,25 +441,31 @@ subroutine wsprimary(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi)
       Fy = Fb * dbdy
       Fp = Fx*l(i) + Fy*m(i) + Fz*n(i)
       delt = -F/Fp
-      !print *, x(i),y(i),z(i)
-      !print *, F, Fx, Fy, Fz
-      !print *, kterm, Fb, flag,k,tan(beta/2)**2
+      !if (isnan(delt)) then
+      !  print *, c,x(i),y(i),z(i)
+      !  print *, F, Fx, Fy, Fz
+      !  print *, kterm, Fb, flag,k,tan(beta/2)**2
+      !  print *, betas,ff
+      !  read *, dum
+      !end if
       x(i) = x(i) + l(i)*delt
       y(i) = y(i) + m(i)*delt
       z(i) = z(i) + n(i)*delt
-      if (c > 10) then
+      if (c > 25 .or. isnan(delt)) then
         delt = 0.
-        l(i) = 0.
-        m(i) = 0.
-        n(i) = 0.
+        x(i) = xi
+        y(i) = yi
+        z(i) = zi
       end if
       c = c + 1
       !read *, dum
     end do
-    Fp = sqrt(Fx*Fx+Fy*Fy+Fz*Fz)
-    ux(i) = -Fx/Fp
-    uy(i) = -Fy/Fp
-    uz(i) = -Fz/Fp
+    if (c < 26) then
+      Fp = sqrt(Fx*Fx+Fy*Fy+Fz*Fz)
+      ux(i) = -Fx/Fp
+      uy(i) = -Fy/Fp
+      uz(i) = -Fz/Fp
+    end if
     !print *, x(i),y(i),z(i)
     !print *, ux(i),uy(i),uz(i)
     !read *, dum
@@ -478,7 +488,7 @@ subroutine wssecondary(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi)
   real*8, intent(in) :: alpha,z0,psi
   real*8 :: k,kterm,dbdx,dbdy,dbdz,dadb,beta,betas,ff,g,d,a
   real*8 :: gam,dbdzs,dadbs
-  real*8 :: F,Fx,Fy,Fz,Fp,delt,dum,Fb
+  real*8 :: F,Fx,Fy,Fz,Fp,delt,dum,Fb,xi,yi,zi
   integer :: i, flag, c
 
   !Compute Chase parameters
@@ -488,10 +498,14 @@ subroutine wssecondary(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi)
   k = tan(betas/2)**2
 
   !Loop through rays and trace to mirror
-  !$omp parallel do private(i,delt,F,Fx,Fy,Fz,Fp,Fb,kterm,beta,dbdx,dbdy,dbdz,flag,c,a,dadbs,dbdzs,gam,dadb)
+  !$omp parallel do private(i,delt,F,Fx,Fy,Fz,Fp,Fb,kterm,beta,dbdx,dbdy,dbdz,flag,c,a,dadbs,dbdzs,gam,dadb,xi,yi,zi)
   do i=1,num
     delt = 100.
     c = 0
+    !Initial ray position
+    xi = x(i)
+    yi = y(i)
+    zi = z(i)
     do while(abs(delt)>1.e-8)
       beta = atan2(sqrt(x(i)**2 + y(i)**2),z(i))
       flag = 0
@@ -544,11 +558,11 @@ subroutine wssecondary(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi)
       x(i) = x(i) + l(i)*delt
       y(i) = y(i) + m(i)*delt
       z(i) = z(i) + n(i)*delt
-      if (c > 10) then
+      if (c > 25 .or. isnan(delt)) then
         delt = 0.
-        l(i) = 0.
-        m(i) = 0.
-        n(i) = 0.
+        x(i) = xi
+        y(i) = yi
+        z(i) = zi
       end if
       !print *, x(i),y(i),z(i)
       !print *, F
@@ -556,10 +570,12 @@ subroutine wssecondary(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi)
       !read *, dum
       c = c+1
     end do
-    Fp = sqrt(Fx*Fx+Fy*Fy+Fz*Fz)
-    ux(i) = Fx/Fp
-    uy(i) = Fy/Fp
-    uz(i) = Fz/Fp
+    if (c < 26) then
+      Fp = sqrt(Fx*Fx+Fy*Fy+Fz*Fz)
+      ux(i) = Fx/Fp
+      uy(i) = Fy/Fp
+      uz(i) = Fz/Fp
+    end if
     !print *, x(i),y(i),z(i)
     !print *, ux(i),uy(i),uz(i)
     !print *, F, Fx, Fy, Fz
@@ -712,7 +728,7 @@ subroutine wsprimaryBack(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi,thick)
   real*8 , intent(inout) :: x(num),y(num),z(num),l(num),m(num),n(num),ux(num),uy(num),uz(num)
   real*8, intent(in) :: alpha,z0,psi,thick
   real*8 :: k,kterm,dbdx,dbdy,beta,betas,ff,g,r,theta,x2,y2
-  real*8 :: F,Fx,Fy,Fz,Fp,delt,dum,Fb
+  real*8 :: F,Fx,Fy,Fz,Fp,delt,dum,Fb,xi,yi,zi
   integer :: i, flag, c
 
   !Compute Chase parameters
@@ -722,10 +738,14 @@ subroutine wsprimaryBack(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi,thick)
   k = tan(betas/2)**2
 
   !Loop through rays and trace to mirror
-  !$omp parallel do private(i,delt,F,Fx,Fy,Fz,Fp,Fb,kterm,beta,dbdx,dbdy,flag,r,x2,y2,theta)
+  !$omp parallel do private(i,delt,F,Fx,Fy,Fz,Fp,Fb,kterm,beta,dbdx,dbdy,flag,r,x2,y2,theta,xi,yi,zi)
   do i=1,num
     delt = 100.
     c = 0
+    !Initial ray position
+    xi = x(i)
+    yi = y(i)
+    zi = z(i)
     do while(abs(delt)>1.e-8)
       !Adjust x and y positions
       r = sqrt(x(i)**2+y(i)**2)
@@ -769,19 +789,21 @@ subroutine wsprimaryBack(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi,thick)
       x(i) = x(i) + l(i)*delt
       y(i) = y(i) + m(i)*delt
       z(i) = z(i) + n(i)*delt
-      if (c > 10) then
+      if (c > 25 .or. isnan(delt)) then
         delt = 0.
-        l(i) = 0.
-        m(i) = 0.
-        n(i) = 0.
+        x(i) = xi
+        y(i) = yi
+        z(i) = zi
       end if
       c = c + 1
       !read *, dum
     end do
-    Fp = sqrt(Fx*Fx+Fy*Fy+Fz*Fz)
-    ux(i) = -Fx/Fp
-    uy(i) = -Fy/Fp
-    uz(i) = -Fz/Fp
+    if (c < 26) then
+      Fp = sqrt(Fx*Fx+Fy*Fy+Fz*Fz)
+      ux(i) = -Fx/Fp
+      uy(i) = -Fy/Fp
+      uz(i) = -Fz/Fp
+    end if
     !print *, x(i),y(i),z(i)
     !print *, ux(i),uy(i),uz(i)
     !read *, dum
@@ -804,7 +826,7 @@ subroutine wssecondaryBack(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi,thick)
   real*8, intent(in) :: alpha,z0,psi,thick
   real*8 :: k,kterm,dbdx,dbdy,dbdz,dadb,beta,betas,ff,g,d,a,r,theta,x2,y2
   real*8 :: gam,dbdzs,dadbs
-  real*8 :: F,Fx,Fy,Fz,Fp,delt,dum,Fb
+  real*8 :: F,Fx,Fy,Fz,Fp,delt,dum,Fb,xi,yi,zi
   integer :: i, flag, c
 
   !Compute Chase parameters
@@ -814,10 +836,14 @@ subroutine wssecondaryBack(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi,thick)
   k = tan(betas/2)**2
 
   !Loop through rays and trace to mirror
-  !$omp parallel do private(i,delt,F,Fx,Fy,Fz,Fp,Fb,kterm,beta,dbdx,dbdy,dbdz,flag,c,a,dadbs,dbdzs,gam,dadb,r,theta,x2,y2)
+  !$omp parallel do private(i,delt,F,Fx,Fy,Fz,Fp,Fb,kterm,beta,dbdx,dbdy,dbdz,flag,c,a,dadbs,dbdzs,gam,dadb,r,theta,x2,y2,xi,yi,zi)
   do i=1,num
     delt = 100.
     c = 0
+    !Initial ray position
+    xi = x(i)
+    yi = y(i)
+    zi = z(i)
     do while(abs(delt)>1.e-8)
       !Adjust x and y positions
       r = sqrt(x(i)**2 + y(i)**2)
@@ -875,11 +901,11 @@ subroutine wssecondaryBack(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi,thick)
       x(i) = x(i) + l(i)*delt
       y(i) = y(i) + m(i)*delt
       z(i) = z(i) + n(i)*delt
-      if (c > 10) then
+      if (c > 25 .or. isnan(delt)) then
         delt = 0.
-        l(i) = 0.
-        m(i) = 0.
-        n(i) = 0.
+        x(i) = xi
+        y(i) = yi
+        z(i) = zi
       end if
       !print *, x(i),y(i),z(i)
       !print *, F
@@ -887,10 +913,12 @@ subroutine wssecondaryBack(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi,thick)
       !read *, dum
       c = c+1
     end do
-    Fp = sqrt(Fx*Fx+Fy*Fy+Fz*Fz)
-    ux(i) = Fx/Fp
-    uy(i) = Fy/Fp
-    uz(i) = Fz/Fp
+    if (c < 26) then
+      Fp = sqrt(Fx*Fx+Fy*Fy+Fz*Fz)
+      ux(i) = Fx/Fp
+      uy(i) = Fy/Fp
+      uz(i) = Fz/Fp
+    end if
     !print *, x(i),y(i),z(i)
     !print *, ux(i),uy(i),uz(i)
     !print *, F, Fx, Fy, Fz

--- a/woltsurf.f95
+++ b/woltsurf.f95
@@ -456,6 +456,7 @@ subroutine wsprimary(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi)
         x(i) = xi
         y(i) = yi
         z(i) = zi
+        c = 1000
       end if
       c = c + 1
       !read *, dum
@@ -563,6 +564,7 @@ subroutine wssecondary(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi)
         x(i) = xi
         y(i) = yi
         z(i) = zi
+        c = 1000
       end if
       !print *, x(i),y(i),z(i)
       !print *, F
@@ -794,6 +796,7 @@ subroutine wsprimaryBack(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi,thick)
         x(i) = xi
         y(i) = yi
         z(i) = zi
+        c = 1000
       end if
       c = c + 1
       !read *, dum
@@ -906,6 +909,7 @@ subroutine wssecondaryBack(x,y,z,l,m,n,ux,uy,uz,num,alpha,z0,psi,thick)
         x(i) = xi
         y(i) = yi
         z(i) = zi
+        c = 1000
       end if
       !print *, x(i),y(i),z(i)
       !print *, F


### PR DESCRIPTION
…s a radius greater than focal length, a nan will result and the ray will be assumed to miss the surface. Same thing if iterations goes beyond 25. Missed rays (for wsPrimary,wsSecondary,wsPrimaryBack,wsSecondaryBack) will simply revert the rays position to its starting position.

I also added a test module in the examples directory. This includes a few functions to launch rays at Wolter-Schwarzschild surfaces over large ranges. I used this to investigate whether the algorithms were robust or not.